### PR TITLE
feat: 알림 기능 구현

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,61 @@
+// Service Worker for Background Notifications
+
+// 설치 이벤트
+self.addEventListener('install', (event) => {
+  console.log('Service Worker 설치됨')
+  self.skipWaiting()
+})
+
+// 활성화 이벤트
+self.addEventListener('activate', (event) => {
+  console.log('Service Worker 활성화됨')
+  event.waitUntil(clients.claim())
+})
+
+// 메시지 받기 (클라이언트에서 알림 스케줄)
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SCHEDULE_NOTIFICATION') {
+    const { delay, missionTitle } = event.data
+    
+    // 알림 스케줄링
+    setTimeout(() => {
+      const title = missionTitle ? `오늘의 미션: ${missionTitle}` : '오늘의 미션을 수행해보세요!'
+      const body = missionTitle 
+        ? '지금 바로 시작해보세요 🎯' 
+        : '매일 새로운 미세먼지 대응 미션을 확인해보세요 🌱'
+      
+      self.registration.showNotification(title, {
+        body: body,
+        icon: '/favicon.ico',
+        badge: '/favicon.ico',
+        tag: 'daily-mission',
+        requireInteraction: true,
+        silent: false,
+        vibrate: [200, 100, 200]
+      })
+    }, delay)
+  }
+})
+
+// 알림 클릭 이벤트
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      // 이미 열린 탭이 있으면 포커스
+      for (const client of clientList) {
+        if (client.url === self.location.origin && 'focus' in client) {
+          return client.focus()
+        }
+      }
+      // 없으면 새 탭 열기
+      if (clients.openWindow) {
+        return clients.openWindow(self.location.origin)
+      }
+    })
+  )
+})
+
+console.log('✅ Service Worker 실행 중... (페이지 닫힐 때만 알림 표시)')
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,6 +6,7 @@ import { fetchDustData, getCurrentLocation, formatCurrentTime, getPM10Grade } fr
 import type { DustData, LocationInfo, DustGrade } from '@/shared/types/api'
 import type { TodoRealLifeAction } from '@/shared/types/todo'
 import todoListData from '@/assets/data/todoList.json'
+import { registerServiceWorker, scheduleNotificationOnUnload, updateNotificationMission } from '@/shared/utils/notifications'
 import './Dashboard.css'
 
 interface DashboardProps {
@@ -202,13 +203,31 @@ export const Dashboard = ({ onNavigateToProfile }: DashboardProps) => {
 
     loadData()
     
+    // Service Worker 등록
+    registerServiceWorker()
+    
+    // 페이지 언로드 감지 (브라우저 닫을 때만 실행)
+    scheduleNotificationOnUnload(10000)
+    
     // 1분마다 시간 업데이트
     const interval = setInterval(() => {
       setCurrentTime(formatCurrentTime())
     }, 60000)
 
-    return () => clearInterval(interval)
+    return () => {
+      clearInterval(interval)
+    }
   }, [])
+
+  // randomMissions가 로드되면 알림 설정 업데이트
+  useEffect(() => {
+    if (randomMissions.length > 0) {
+      const randomMission = randomMissions[Math.floor(Math.random() * randomMissions.length)]
+      // 미션 제목만 업데이트 (이벤트 리스너는 이미 등록됨)
+      updateNotificationMission(randomMission.title)
+      console.log('미션 알림 업데이트:', randomMission.title)
+    }
+  }, [randomMissions])
 
 
   return (

--- a/src/shared/utils/notifications.ts
+++ b/src/shared/utils/notifications.ts
@@ -1,0 +1,68 @@
+/**
+ * 웹 브라우저 알림 유틸리티
+ */
+
+/**
+ * 서비스 워커 등록 및 백그라운드 알림 스케줄링
+ */
+export const registerServiceWorker = async (): Promise<void> => {
+  if ('serviceWorker' in navigator) {
+    try {
+      const registration = await navigator.serviceWorker.register('/sw.js')
+      console.log('✅ Service Worker 등록됨:', registration.scope)
+    } catch (error) {
+      console.error('❌ Service Worker 등록 실패:', error)
+    }
+  }
+}
+
+/**
+ * 브라우저 닫힌 시점을 감지해서 알림 스케줄링
+ * 중복 실행 방지를 위한 플래그
+ */
+let hasListenerAdded = false
+let currentMissionTitle: string | undefined = undefined
+
+/**
+ * 미션 제목만 업데이트
+ */
+export const updateNotificationMission = (missionTitle: string) => {
+  currentMissionTitle = missionTitle
+  console.log('📝 미션 알림 내용 업데이트:', missionTitle)
+}
+
+export const scheduleNotificationOnUnload = (delay: number = 10000, missionTitle?: string) => {
+  // 미션 제목 설정
+  if (missionTitle) {
+    currentMissionTitle = missionTitle
+  }
+
+  // 이미 이벤트 리스너가 등록되었으면 리턴
+  if (hasListenerAdded) {
+    console.log('⚠️ 이벤트 리스너가 이미 등록되어 있습니다.')
+    return
+  }
+
+  const beforeUnloadHandler = () => {
+    console.log('🚪 페이지 닫힘 감지 - 알림 스케줄링 시작')
+    // Service Worker가 활성화되어 있으면 알림 스케줄링
+    if ('serviceWorker' in navigator) {
+      // Service Worker로 메시지 전송 (페이지 닫힌 후 실행됨)
+      if (navigator.serviceWorker.controller) {
+        navigator.serviceWorker.controller.postMessage({
+          type: 'SCHEDULE_NOTIFICATION',
+          delay: delay,
+          missionTitle: currentMissionTitle
+        })
+        console.log('📤 Service Worker로 알림 요청 전송:', currentMissionTitle)
+      }
+    }
+  }
+  
+  // beforeunload만 사용 (페이지를 완전히 닫을 때만)
+  window.addEventListener('beforeunload', beforeUnloadHandler)
+  hasListenerAdded = true
+  
+  console.log('✅ 페이지 언로드 감지 설정 완료 (브라우저를 닫을 때만 알림 표시)')
+}
+


### PR DESCRIPTION
### 🎯 작업 목표
- 브라우저 종료 10초 후 미세먼지 대응 미션 알림 발송
- Service Worker로 백그라운드 알림 지원
- 불필요한 알림 중복 방지

### ✨ 주요 변경사항

#### 1. Service Worker 추가 (`public/sw.js`)
- 브라우저 종료 후 백그라운드 알림 처리
- 메시지 수신 시 10초 지연 후 알림 표시
- 알림 클릭 시 앱으로 이동

#### 2. 알림 유틸리티 개선 (`src/shared/utils/notifications.ts`)
- `registerServiceWorker()`: Service Worker 등록
- `scheduleNotificationOnUnload()`: 브라우저 종료 감지 및 알림 스케줄링
- `updateNotificationMission()`: 미션 제목 업데이트
- 중복 알림 방지 로직

#### 3. Dashboard 통합 (`src/pages/Dashboard.tsx`)
- Service Worker 등록
- 랜덤 미션 로드 후 알림에 미션 제목 포함
- 브라우저 종료 시에만 알림 스케줄링

### 🗑️ 제거된 코드
- 불필요한 `sync`, `push` 이벤트 리스너
- 사용하지 않는 `showDailyMissionNotification()`, `showMissionCompleteNotification()` 함수
- 1분마다 자동 체크하던 `setInterval` 로직
- 캐시 관련 불필요한 함수들

### 🔧 동작 방식
1. 사용자가 페이지를 열면 Service Worker 등록
2. 랜덤 미션 로드 시 알림에 미션 제목 설정
3. 브라우저 종료 시(`beforeunload`) 알림 스케줄링 메시지 전송
4. Service Worker가 10초 후 알림 표시
5. 알림 클릭 시 앱으로 이동