### PR TITLE
refactor: 미세먼지 수치 UI에 색상으로 반영 (Header, 모달)

### DIFF
--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -958,6 +958,12 @@
 .behavioral-modal-content-all {
   max-width: 700px;
   max-height: 85vh;
+  overflow: hidden;
+}
+
+.behavioral-modal-content-all .behavioral-modal-header {
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
 }
 
 .behavioral-modal-subtitle {
@@ -1017,16 +1023,7 @@
   border-left: 3px solid #10b981;
 }
 
-/* 프로필 반영된 섹션 강조 */
-.behavioral-guide-section:has(.behavioral-modal-profile-badge) {
-  background: linear-gradient(135deg, #f0fdf4 0%, #f8fafc 100%);
-  border-color: #86efac;
-  border-width: 2px;
-}
-
-.behavioral-guide-section:has(.behavioral-modal-profile-badge) .behavioral-guide-title {
-  color: #059669;
-}
+/* 프로필 반영된 섹션 강조 - 동적 스타일로 인라인에서 처리 */
 
 /* 모바일 대응 */
 @media (max-width: 768px) {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -574,7 +574,12 @@ export const Dashboard = ({ onNavigateToProfile }: DashboardProps) => {
 
     <div className={`smart-home-dashboard ${!isLaptop ? 'mobile-layout' : ''}`}>
       {/* 상단 헤더 */}
-      <header className="dashboard-header">
+      <header 
+        className="dashboard-header"
+        style={dustMood ? {
+          backgroundColor: dustMood.bgColor
+        } : {}}
+      >
         <div className="header-left">
           <div className="brand-logo">
             <span>Finedust</span>
@@ -899,7 +904,13 @@ export const Dashboard = ({ onNavigateToProfile }: DashboardProps) => {
       {showBehavioralModal && (
         <div className="behavioral-modal-overlay" onClick={() => setShowBehavioralModal(false)}>
           <div className="behavioral-modal-content behavioral-modal-content-all" onClick={(e) => e.stopPropagation()}>
-            <div className="behavioral-modal-header">
+            <div 
+              className="behavioral-modal-header"
+              style={dustMood ? {
+                backgroundColor: dustMood.bgColor,
+                borderBottomColor: dustMood.color
+              } : {}}
+            >
               <div>
                 <h2 className="behavioral-modal-title">전체 행동 방안</h2>
                 <p className="behavioral-modal-subtitle">프로필에 맞는 행동 방안이 상단에 표시됩니다</p>
@@ -912,9 +923,24 @@ export const Dashboard = ({ onNavigateToProfile }: DashboardProps) => {
             </div>
             <div className="behavioral-modal-body behavioral-modal-body-all">
               {behavioralModalGuides.map((guide, guideIndex) => (
-                <div key={guideIndex} className="behavioral-guide-section">
+                <div 
+                  key={guideIndex} 
+                  className="behavioral-guide-section"
+                  style={guide.profileApplied.length > 0 && dustMood ? {
+                    background: `linear-gradient(135deg, ${dustMood.bgColor} 0%, #f8fafc 100%)`,
+                    borderColor: dustMood.color,
+                    borderWidth: '2px'
+                  } : {}}
+                >
                   <div className="behavioral-guide-header">
-                    <h3 className="behavioral-guide-title">{guide.title}</h3>
+                    <h3 
+                      className="behavioral-guide-title"
+                      style={guide.profileApplied.length > 0 && dustMood ? {
+                        color: dustMood.color
+                      } : {}}
+                    >
+                      {guide.title}
+                    </h3>
                     {guide.profileApplied.length > 0 && (
                       <div className="behavioral-modal-profile-badge">
                         <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
@@ -939,10 +965,20 @@ export const Dashboard = ({ onNavigateToProfile }: DashboardProps) => {
                                            text.includes('식물') ? '반려식물 사러 가기' : '구매 링크'
                         
                         return (
-                          <p key={index} className="behavioral-modal-text">
+                          <p 
+                            key={index} 
+                            className="behavioral-modal-text"
+                            style={dustMood ? { borderLeftColor: dustMood.color } : {}}
+                          >
                             {text && <span>{text}</span>}
                             {url && (
-                              <a href={url} target="_blank" rel="noopener noreferrer" className="behavioral-modal-link">
+                              <a 
+                                href={url} 
+                                target="_blank" 
+                                rel="noopener noreferrer" 
+                                className="behavioral-modal-link"
+                                style={dustMood ? { color: dustMood.color } : {}}
+                              >
                                 {displayText}
                               </a>
                             )}
@@ -958,9 +994,19 @@ export const Dashboard = ({ onNavigateToProfile }: DashboardProps) => {
                                            item.includes('대한천식') ? '대한천식알레르기학회 바로가기' : '바로가기'
                         
                         return (
-                          <p key={index} className="behavioral-modal-text">
+                          <p 
+                            key={index} 
+                            className="behavioral-modal-text"
+                            style={dustMood ? { borderLeftColor: dustMood.color } : {}}
+                          >
                             {url && (
-                              <a href={url} target="_blank" rel="noopener noreferrer" className="behavioral-modal-link">
+                              <a 
+                                href={url} 
+                                target="_blank" 
+                                rel="noopener noreferrer" 
+                                className="behavioral-modal-link"
+                                style={dustMood ? { color: dustMood.color } : {}}
+                              >
                                 {displayText}
                               </a>
                             )}
@@ -968,7 +1014,15 @@ export const Dashboard = ({ onNavigateToProfile }: DashboardProps) => {
                         )
                       }
                       
-                      return <p key={index} className="behavioral-modal-text">{item}</p>
+                      return (
+                        <p 
+                          key={index} 
+                          className="behavioral-modal-text"
+                          style={dustMood ? { borderLeftColor: dustMood.color } : {}}
+                        >
+                          {item}
+                        </p>
+                      )
                     })}
                   </div>
                 </div>

--- a/src/widgets/House3D/House3D.css
+++ b/src/widgets/House3D/House3D.css
@@ -227,6 +227,8 @@
   padding: 20px 24px;
   border-bottom: 1px solid #e2e8f0;
   gap: 16px;
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
 }
 
 .behavioral-modal-header > div:first-child {

--- a/src/widgets/House3D/House3D.tsx
+++ b/src/widgets/House3D/House3D.tsx
@@ -3,6 +3,8 @@ import { useState, useEffect } from 'react'
 import { useMediaQuery } from 'react-responsive'
 import type { Application } from '@splinetool/runtime'
 import behavioralGuidelines from '@/assets/data/behavioral_guidelines.json'
+import { getPM10Grade } from '@/shared/api/dustApi'
+import type { DustGrade } from '@/shared/types/api'
 import './House3D.css'
 
 interface House3DProps {
@@ -33,6 +35,38 @@ export const House3D = ({ pm10Value, userHealth, userAge, userChild, userPet }: 
     if (pm10 <= 80) return 'moderate'
     if (pm10 <= 150) return 'bad'
     return 'very_bad'
+  }
+
+  // 미세먼지 등급에 따른 색상 가져오기
+  const getDustColor = (pm10?: number): string => {
+    if (!pm10) return '#10b981'
+    const grade = getPM10Grade(pm10)
+    const colorMap: Record<DustGrade, string> = {
+      '매우 좋음': '#4285F4',
+      '좋음': '#1976D2',
+      '양호': '#22B14C',
+      '보통': '#B5E61D',
+      '주의': '#FFD400',
+      '나쁨': '#FF7F27',
+      '매우 나쁨': '#F52020'
+    }
+    return colorMap[grade] || '#10b981'
+  }
+
+  // 미세먼지 등급에 따른 배경색 가져오기
+  const getDustBgColor = (pm10?: number): string => {
+    if (!pm10) return '#E3F2FD'
+    const grade = getPM10Grade(pm10)
+    const bgColorMap: Record<DustGrade, string> = {
+      '매우 좋음': '#D0E8F2',
+      '좋음': '#E3F2FD',
+      '양호': '#F1F8E9',
+      '보통': '#FFF8E1',
+      '주의': '#FFF3E0',
+      '나쁨': '#FFEBEE',
+      '매우 나쁨': '#FCE4EC'
+    }
+    return bgColorMap[grade] || '#E3F2FD'
   }
 
   // 스플라인 로드 후 초기값 설정 및 모달 활성화
@@ -218,7 +252,13 @@ export const House3D = ({ pm10Value, userHealth, userAge, userChild, userPet }: 
           setNowSelectedObject('none')
         }}>
           <div className="behavioral-modal-content" onClick={(e) => e.stopPropagation()}>
-            <div className="behavioral-modal-header">
+            <div 
+              className="behavioral-modal-header"
+              style={{
+                backgroundColor: getDustBgColor(pm10Value),
+                borderBottomColor: getDustColor(pm10Value)
+              }}
+            >
               <div>
                 <h2 className="behavioral-modal-title">{modalTitle}</h2>
                 {modalProfileApplied.length > 0 && (
@@ -255,10 +295,20 @@ export const House3D = ({ pm10Value, userHealth, userAge, userChild, userPet }: 
                                      text.includes('식물') ? '반려식물 사러 가기' : '구매 링크'
                   
                   return (
-                    <p key={index} className="behavioral-modal-text">
+                    <p 
+                      key={index} 
+                      className="behavioral-modal-text"
+                      style={{ borderLeftColor: getDustColor(pm10Value) }}
+                    >
                       {text && <span>{text}</span>}
                       {url && (
-                        <a href={url} target="_blank" rel="noopener noreferrer" className="behavioral-modal-link">
+                        <a 
+                          href={url} 
+                          target="_blank" 
+                          rel="noopener noreferrer" 
+                          className="behavioral-modal-link"
+                          style={{ color: getDustColor(pm10Value) }}
+                        >
                           {displayText}
                         </a>
                       )}
@@ -274,9 +324,19 @@ export const House3D = ({ pm10Value, userHealth, userAge, userChild, userPet }: 
                                      item.includes('대한천식') ? '대한천식알레르기학회 바로가기' : '바로가기'
                   
                   return (
-                    <p key={index} className="behavioral-modal-text">
+                    <p 
+                      key={index} 
+                      className="behavioral-modal-text"
+                      style={{ borderLeftColor: getDustColor(pm10Value) }}
+                    >
                       {url && (
-                        <a href={url} target="_blank" rel="noopener noreferrer" className="behavioral-modal-link">
+                        <a 
+                          href={url} 
+                          target="_blank" 
+                          rel="noopener noreferrer" 
+                          className="behavioral-modal-link"
+                          style={{ color: getDustColor(pm10Value) }}
+                        >
                           {displayText}
                         </a>
                       )}
@@ -284,7 +344,15 @@ export const House3D = ({ pm10Value, userHealth, userAge, userChild, userPet }: 
                   )
                 }
                 
-                return <p key={index} className="behavioral-modal-text">{item}</p>
+                return (
+                  <p 
+                    key={index} 
+                    className="behavioral-modal-text"
+                    style={{ borderLeftColor: getDustColor(pm10Value) }}
+                  >
+                    {item}
+                  </p>
+                )
               })}
             </div>
           </div>


### PR DESCRIPTION
## 변경 사항

### 주요 기능
미세먼지 수치 변화를 UI 색상으로 즉시 반영

1. Header 배경색 동적 변경
   - Dashboard 상단 Header 배경색이 미세먼지 등급에 따라 변경
   - 등급별 색상: 매우 좋음/좋음(파란색), 양호/보통(초록/노란색), 주의/나쁨/매우 나쁨(노란색/주황색/빨간색)

2. 모달 헤더 배경색 동적 변경
   - 행동 방안 모달 헤더 배경색이 미세먼지 등급에 따라 변경
   - Dashboard 전체 행동 방안 모달과 House3D 컴포넌트 모달 모두 적용
   - 모달 헤더 상단 모서리 border-radius 유지

3. 행동 방안 모달의 프로필 반영 섹션 강조 색상 동적 변경
   - 프로필 반영 섹션 배경색: 미세먼지 등급 배경색 기반 그라데이션
   - 테두리 색상: 미세먼지 등급 색상
   - 제목 색상: 미세먼지 등급 색상

4. 링크 색상 동적 변경
   - Dashboard 행동 방안 모달의 모든 링크 색상
   - House3D 컴포넌트 모달의 모든 링크 색상
   - 미세먼지 등급에 따라 자동 변경

5. 텍스트 항목 왼쪽 테두리 색상 동적 변경
   - 각 행동 방안 텍스트의 왼쪽 테두리 색상이 미세먼지 등급에 따라 변경
   - Dashboard 모달과 House3D 모달 모두 적용

## 기술적 변경 사항

### 컴포넌트 수정
- `src/pages/Dashboard.tsx`
  - Header에 `dustMood.bgColor` 동적 적용
  - 모달 헤더에 `dustMood.bgColor`, `dustMood.color` 동적 적용
  - 프로필 반영 섹션에 동적 색상 스타일 적용
  - 모든 링크에 `dustMood.color` 동적 적용
  - 모든 텍스트 항목에 `borderLeftColor` 동적 적용

- `src/widgets/House3D/House3D.tsx`
  - `getDustColor()` 함수 추가: 미세먼지 등급에 따른 색상 반환
  - `getDustBgColor()` 함수 추가: 미세먼지 등급에 따른 배경색 반환
  - 모달 헤더에 동적 배경색 및 테두리 색상 적용
  - 모든 링크에 동적 색상 적용
  - 모든 텍스트 항목에 동적 테두리 색상 적용

### 스타일 수정
- `src/pages/Dashboard.css`
  - 모달 헤더 상단 모서리 border-radius 추가 (`border-top-left-radius`, `border-top-right-radius`)
  - 모달 컨텐츠에 `overflow: hidden` 추가

- `src/widgets/House3D/House3D.css`
  - 모달 헤더 상단 모서리 border-radius 추가

## UI/UX 개선
- 미세먼지 수치 변화를 UI 색상으로 즉시 반영
- Header, 모달, 링크 등 주요 UI 요소의 색상이 미세먼지 등급에 따라 동적 변경
- 사용자가 미세먼지 상태를 색상으로 빠르게 인지 가능

## 테스트
- [x] 미세먼지 수치 변경 시 Header 배경색 변경 확인
- [x] 미세먼지 수치 변경 시 모달 헤더 배경색 변경 확인
- [x] 미세먼지 수치 변경 시 프로필 반영 섹션 강조 색상 변경 확인
- [x] 미세먼지 수치 변경 시 링크 색상 변경 확인
- [x] 미세먼지 수치 변경 시 텍스트 테두리 색상 변경 확인
- [x] 모달 헤더 모서리 둥글게 유지 확인